### PR TITLE
Match latest discord changes on avatars

### DIFF
--- a/components/GuildProfileModal.jsx
+++ b/components/GuildProfileModal.jsx
@@ -39,7 +39,7 @@ getModuleByDisplayName('InviteButton', true, true).then((Button) => {
 const DiscordTag = AsyncComponent.from(getModuleByDisplayName('DiscordTag'));
 
 const { GuildIcon } = getModule(['GuildIcon'], false);
-const { Avatar } = getModule(['Avatar'], false);
+const { default: Avatar } = getModule(['AnimatedAvatar'], false);
 
 const UserProfileModalActionCreators = getModule(
   ['fetchProfile', 'open'],
@@ -120,7 +120,7 @@ class RelationshipRow extends React.PureComponent {
       >
         <Avatar
           className={this.classes.listAvatar}
-          src={user.avatarURL}
+          src={user.getAvatarURL()}
           size='SIZE_40'
           status={status}
         />


### PR DESCRIPTION
Match the latest changes discord made on the user profile, fixing the issue seen in the image below.

![image](https://user-images.githubusercontent.com/40345645/120087741-e7320180-c0c0-11eb-9d08-fbbd04094c5e.png)
