### PR TITLE
Force load lazy loaded class modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = class GuildProfile extends Plugin {
 
     // Powercord doesn't provide the full webpack require instance object sadly.
     const req = webpackChunkdiscord_app.push([[Symbol()], [], _ => _]);
+    webpackChunkdiscord_app.pop();
 
     let modules = [];
     for (const id in req.m) {


### PR DESCRIPTION
This was originally pointed out by Strencher in the powercord server. A couple of the class modules are lazy loaded and if you haven't opened the User Modal since restart the styles will be all fucked up in the Guild Modal.

I tried changing my code formatter to match your formatting but your formatting is all over the place with some brackets being spaced and other not being spaced. The brackets not being spaced seemed to be the most common so I went with that.