### PR TITLE
fix: copy some modal styling from discord as it's lazy loaded

### DIFF
--- a/components/GuildProfileModal.jsx
+++ b/components/GuildProfileModal.jsx
@@ -29,7 +29,8 @@ class GuildProfileTabBar extends React.PureComponent {
     super(props);
 
     this.modules = {
-      ...getModule(['topSection'], false),
+      ...getModule([ 'top', 'item' ], false),
+      ...getModule([ 'tabBarContainer', 'tabBarItemSpacing' ], false),
     };
   }
   render() {
@@ -72,7 +73,8 @@ class GuildProfileModal extends React.PureComponent {
     super(props);
 
     this.modules = {
-      ...getModule(['topSection'], false),
+      ...getModule([ 'top', 'item' ], false),
+      ...getModule([ 'tabBarContainer', 'tabBarItemSpacing' ], false)
     };
 
     this.state = {
@@ -115,8 +117,8 @@ class GuildProfileModal extends React.PureComponent {
     }
 
     return (
-      <ModalRoot className={this.modules.root} transitionState={1}>
-        <div className={this.modules.topSection}>
+      <ModalRoot className="guild-profile-root" transitionState={1}>
+        <div className="guild-profile-topsection">
           <GuildProfileHeader guild={guild} counts={counts} />
           <GuildProfileTabBar
             setSection={(section) => this.setState({ section })}
@@ -124,7 +126,7 @@ class GuildProfileModal extends React.PureComponent {
             guild={guild}
           />
         </div>
-        <div className={this.modules.body}>{section}</div>
+        <div className="guild-profile-body">{section}</div>
       </ModalRoot>
     );
   }

--- a/styles.scss
+++ b/styles.scss
@@ -20,3 +20,22 @@
   overflow: hidden;
   width: 100%;
 }
+
+/* Copied from Discord as it's lazy loaded from profile modal so breaks appearance if it hasn't been opened before */
+.guild-profile-root {
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+  width: 600px;
+  background-color: var(--background-floating);
+  max-height: unset;
+  box-shadow: none !important;
+}
+
+.guild-profile-topsection {
+  background-color: var(--background-floating);
+}
+
+.guild-profile-body {
+  height: 240px;
+}


### PR DESCRIPTION
Uses CSS copied from Discord as it's lazy loaded from profile modal so breaks appearance if it hasn't been opened before.

Looks like this otherwise:
![image](https://user-images.githubusercontent.com/19228318/177197322-403439da-e7a6-470b-a555-880393a845cd.png)