### PR TITLE
Replace dirtyDispatch with dispatch to avoid crashes

### DIFF
--- a/memberCountsStore/actions.js
+++ b/memberCountsStore/actions.js
@@ -8,7 +8,7 @@ const { FluxActions } = require('../constants');
 
 module.exports = {
   updateMemberCounts: async (memberCountsUpdate) => {
-    FluxDispatcher.dirtyDispatch({
+    FluxDispatcher.dispatch({
       type: FluxActions.UPDATE_MEMBER_COUNTS,
       ...memberCountsUpdate
     });


### PR DESCRIPTION
As per recommendation from Replugged developers.